### PR TITLE
Cleanup error handling

### DIFF
--- a/ImageStore/ImageStore.swift
+++ b/ImageStore/ImageStore.swift
@@ -36,9 +36,7 @@ struct ImageStore {
             throw NSError(description: "The image path could not be retrieved")
         }
         
-        do {
-            try imageData.write(to: imagePath)
-        }
+        try imageData.write(to: imagePath)
     }
     
     private static func path(for imageName: String, fileExtension: String = "png") -> URL? {


### PR DESCRIPTION
`store(image:name:)` is a throwing function, so we do not need the `do` block in order to pass an error.